### PR TITLE
feat(cockpit): add cockpit module for dgx-spark

### DIFF
--- a/hosts/dgx-spark/configuration.nix
+++ b/hosts/dgx-spark/configuration.nix
@@ -76,6 +76,9 @@
   # ─── DS4 Server ─────────────────────────────────────────────────────
   services.ds4.enable = true;
 
+  # ─── Cockpit Web Manager ────────────────────────────────────────────
+  services.cockpit-local.enable = true;
+
   # ─── Lance Multimodal AI ────────────────────────────────────────────
   services.lance = {
     enable = false;

--- a/hosts/dgx-spark/default.nix
+++ b/hosts/dgx-spark/default.nix
@@ -4,6 +4,7 @@
   imports = [
     inputs.dgx-spark.nixosModules.dgx-spark
     inputs.disko.nixosModules.disko
+    ../../modules/cockpit.nix
     ../../modules/ds4.nix
     ../../modules/lance.nix
     ./disk-config.nix

--- a/modules/cockpit.nix
+++ b/modules/cockpit.nix
@@ -1,0 +1,81 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  inherit (lib)
+    mkIf
+    mkEnableOption
+    mkOption
+    types
+    mkDefault
+    ;
+  cfg = config.services.cockpit-local;
+in
+{
+  options.services.cockpit-local = {
+    enable = mkEnableOption "Cockpit web-based server manager";
+
+    port = mkOption {
+      type = types.port;
+      default = 9090;
+      description = "TCP port for Cockpit web UI.";
+    };
+
+    openFirewall = mkOption {
+      type = types.bool;
+      default = true;
+      description = "Open firewall for Cockpit web UI.";
+    };
+  };
+
+  config = mkIf cfg.enable {
+    # Enable nixpkgs' built-in Cockpit module
+    services.cockpit = {
+      enable = true;
+      port = cfg.port;
+      openFirewall = cfg.openFirewall;
+
+      # Add cockpit plugins
+      plugins = with pkgs; [
+        cockpit-machines
+        cockpit-podman
+      ];
+    };
+
+    # Allow access from LAN hostnames (merges with nixpkgs default localhost origin)
+    services.cockpit.allowed-origins = [
+      "https://${config.networking.hostName}.local:${toString cfg.port}"
+      "http://${config.networking.hostName}.local:${toString cfg.port}"
+      "https://${config.networking.hostName}:${toString cfg.port}"
+      "http://${config.networking.hostName}:${toString cfg.port}"
+    ];
+
+    # Allow unencrypted HTTP on LAN (no self-signed cert warnings)
+    services.cockpit.settings.WebService.AllowUnencrypted = mkDefault true;
+
+    # cockpit-session needs cockpit-bridge in PATH (nixpkgs module no longer adds it)
+    environment.systemPackages = [ pkgs.cockpit ];
+
+    # Advertise via mDNS so spark.local:9090 is discoverable
+    services.avahi = {
+      publish.enable = true;
+      extraServiceFiles = {
+        cockpit = ''
+          <?xml version="1.0" standalone='no'?>
+          <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+          <service-group>
+            <name replace-wildcards="yes">DGX Spark Cockpit (%h)</name>
+            <service>
+              <type>_http._tcp</type>
+              <port>${toString cfg.port}</port>
+            </service>
+          </service-group>
+        '';
+      };
+    };
+  };
+}

--- a/modules/default.nix
+++ b/modules/default.nix
@@ -45,6 +45,7 @@
     ];
 
     linux.imports = [
+      ./cockpit.nix
       ./ds4.nix
       ./lance.nix
       ./mullvad.nix


### PR DESCRIPTION
- Create modules/cockpit.nix wrapping nixpkgs services.cockpit
- Configures AllowUnencrypted=true for LAN access
- Adds allowed-origins for dgx-spark.local hostname
- Includes cockpit-machines + cockpit-podman plugins
- Adds avahi mDNS advertisement
- Restores cockpit-bridge in system packages (removed upstream)
- Enables on dgx-spark host