### PR TITLE
Fix emacsclient -nw by skipping GUI setup on tty frames.

### DIFF
--- a/modules/editor/emacs/configs/prot-modeline-hel.el
+++ b/modules/editor/emacs/configs/prot-modeline-hel.el
@@ -18,17 +18,15 @@ Shows the Hel state when `hel-mode' is active, otherwise shows nothing."
       (propertize (format " %s " state-name) 'face face))))
 
 (with-eval-after-load 'hel
-  ;; Suppress hel's own mode-line-misc-info entry (multiple cursors / search)
-  ;; since we display the state here instead. Users can still see search
-  ;; progress via the built-in mechanism if desired.
   (setq hel-mode-line-info nil)
 
-  ;; Insert the hel state indicator into the mode-line format
-  ;; (replacing the empty string placeholder from prot-modeline.el).
-  (setq-default mode-line-format
-                (cl-substitute
-                 '(:eval (prot-modeline--hel-state)) ""
-                 (default-value 'mode-line-format)
-                 :test 'equal :count 1)))
+  ;; Insert the hel state indicator into the graphical mode-line format only.
+  (setq my/graphical-mode-line-format
+        (cl-substitute '(:eval (prot-modeline--hel-state)) ""
+                       my/graphical-mode-line-format
+                       :test 'equal :count 1))
+
+  (when-let ((frame (selected-frame)))
+    (my/ensure-mode-line-for-frame frame)))
 
 ;;; prot-modeline-hel.el ends here

--- a/modules/editor/emacs/configs/prot-modeline-meow.el
+++ b/modules/editor/emacs/configs/prot-modeline-meow.el
@@ -16,31 +16,32 @@ Shows the Meow state when `meow-mode' is active, otherwise shows EMACS."
    (t nil)))
 
 (with-eval-after-load 'meow
-  ;; Style meow's state indicator faces to match prot-modeline's look.
-  ;; Each state gets a colored background using prot-modeline indicator faces.
-  (set-face-attribute 'meow-normal-indicator nil
-                      :inherit 'prot-modeline-indicator-green-bg)
-  (set-face-attribute 'meow-insert-indicator nil
-                      :inherit 'prot-modeline-indicator-yellow-bg)
-  (set-face-attribute 'meow-motion-indicator nil
-                      :inherit 'prot-modeline-indicator-blue-bg)
-  (set-face-attribute 'meow-keypad-indicator nil
-                      :inherit 'prot-modeline-indicator-red-bg)
-  (set-face-attribute 'meow-beacon-indicator nil
-                      :inherit 'prot-modeline-indicator-magenta-bg)
+  (when (display-graphic-p)
+    ;; Style meow's state indicator faces to match prot-modeline's look.
+    (set-face-attribute 'meow-normal-indicator nil
+                        :inherit 'prot-modeline-indicator-green-bg)
+    (set-face-attribute 'meow-insert-indicator nil
+                        :inherit 'prot-modeline-indicator-yellow-bg)
+    (set-face-attribute 'meow-motion-indicator nil
+                        :inherit 'prot-modeline-indicator-blue-bg)
+    (set-face-attribute 'meow-keypad-indicator nil
+                        :inherit 'prot-modeline-indicator-red-bg)
+    (set-face-attribute 'meow-beacon-indicator nil
+                        :inherit 'prot-modeline-indicator-magenta-bg))
 
   ;; Suppress meow's built-in minor mode lighters (" [N]", " [I]", etc.)
-  ;; since we display the state via `prot-modeline--meow-or-emacs'.
   (dolist (mode '(meow-normal-mode meow-insert-mode meow-motion-mode
                   meow-keypad-mode meow-beacon-mode))
     (when-let* ((entry (assq mode minor-mode-alist)))
       (setcdr entry (list nil))))
 
-  ;; Insert the meow indicator into the mode-line format (replacing the empty string)
-  (setq-default mode-line-format
-                (cl-substitute
-                 '(:eval (prot-modeline--meow-or-emacs)) ""
-                 (default-value 'mode-line-format)
-                 :test 'equal :count 1)))
+  ;; Insert the meow indicator into the graphical mode-line format only.
+  (setq my/graphical-mode-line-format
+        (cl-substitute '(:eval (prot-modeline--meow-or-emacs)) ""
+                       my/graphical-mode-line-format
+                       :test 'equal :count 1))
+
+  (when-let ((frame (selected-frame)))
+    (my/ensure-mode-line-for-frame frame)))
 
 ;;; prot-modeline-meow.el ends here

--- a/modules/editor/emacs/configs/prot-modeline.el
+++ b/modules/editor/emacs/configs/prot-modeline.el
@@ -8,46 +8,78 @@
 (setq mode-line-compact nil) ; Emacs 28
 (setq mode-line-right-align-edge 'right-margin) ; Emacs 30
 
+(defvar my/tty-mode-line-format
+  '("%b %f  %l:%c  %m")
+  "Simple mode line for terminal frames (emacsclient -nw).")
+
 ;; ── Mode-line format ───────────────────────────────────────────────
-;; The meow indicator is added separately by prot-modeline-meow.el
-;; when modal editing is set to "meow".
-(setq-default mode-line-format
-     '("%e"
-       ""
-       prot-modeline-kbd-macro
-       prot-modeline-narrow
-       prot-modeline-buffer-status
-       prot-modeline-window-dedicated-status
-       prot-modeline-input-method
-       "  "
-       prot-modeline-buffer-identification
-       "  "
-       prot-modeline-major-mode
-       "  "
-       mode-line-position
-       "  "
-       prot-modeline-process
-       "  "
-       prot-modeline-vc-branch
-       "  "
-       prot-modeline-eglot
-       "  "
-       prot-modeline-flymake
-       "  "
-       mode-line-format-right-align ; Emacs 30
-       prot-modeline-notmuch-indicator
-       "  "
-       prot-modeline-misc-info))
+;; The meow/hel indicator is added separately by prot-modeline-meow.el
+;; or prot-modeline-hel.el when modal editing is enabled.
+(defvar my/graphical-mode-line-format
+  '("%e"
+    ""
+    prot-modeline-kbd-macro
+    prot-modeline-narrow
+    prot-modeline-buffer-status
+    prot-modeline-window-dedicated-status
+    prot-modeline-input-method
+    "  "
+    prot-modeline-buffer-identification
+    "  "
+    prot-modeline-major-mode
+    "  "
+    mode-line-position
+    "  "
+    prot-modeline-process
+    "  "
+    prot-modeline-vc-branch
+    "  "
+    prot-modeline-eglot
+    "  "
+    prot-modeline-flymake
+    "  "
+    mode-line-format-right-align ; Emacs 30
+    prot-modeline-notmuch-indicator
+    "  "
+    prot-modeline-misc-info)
+  "Prot modeline format for graphical frames.")
+
+(defun my/mode-line-format-for-frame (&optional frame)
+  "Return an appropriate `mode-line-format' for FRAME."
+  (if (display-graphic-p (or frame (selected-frame)))
+      my/graphical-mode-line-format
+    my/tty-mode-line-format))
+
+(defun my/ensure-mode-line-for-frame (&optional frame)
+  "Use prot-modeline on graphical frames; a plain line on terminals."
+  (when-let ((frame (or frame (selected-frame))))
+    (let ((format (my/mode-line-format-for-frame frame)))
+      (dolist (buf (buffer-list))
+        (when (get-buffer-window buf frame)
+          (with-current-buffer buf
+            (unless (equal mode-line-format format)
+              (setq mode-line-format format))))))))
+
+;; Safe default: terminal-friendly. Graphical frames opt in via the hook.
+(setq-default mode-line-format my/tty-mode-line-format)
+
+(when-let ((frame (selected-frame)))
+  (my/ensure-mode-line-for-frame frame))
+
+(add-hook 'server-after-make-frame-hook #'my/ensure-mode-line-for-frame)
+(add-hook 'window-configuration-change-hook #'my/ensure-mode-line-for-frame)
 
 (with-eval-after-load 'spacious-padding
   (defun prot/modelline-spacious-indicators ()
     "Set box attribute to `'prot-modeline-indicator-button' if spacious-padding is enabled."
-    (if (bound-and-true-p spacious-padding-mode)
-        (set-face-attribute 'prot-modeline-indicator-button nil :box t)))
+    (when (display-graphic-p)
+      (if (bound-and-true-p spacious-padding-mode)
+          (set-face-attribute 'prot-modeline-indicator-button nil :box t))))
 
   ;; Run it at startup and then afterwards whenever
   ;; `spacious-padding-mode' is toggled on/off.
-  (prot/modelline-spacious-indicators)
+  (when (display-graphic-p)
+    (prot/modelline-spacious-indicators))
   (add-hook 'spacious-padding-mode-hook #'prot/modelline-spacious-indicators))
 
 ;;; prot-modeline-config.el ends here

--- a/modules/editor/emacs/default.nix
+++ b/modules/editor/emacs/default.nix
@@ -159,13 +159,19 @@ with lib;
                                                       (push '(vertical-scroll-bars . nil) default-frame-alist)
                                                       ;; no title bar
                                                       (add-to-list 'default-frame-alist '(undecorated-round . t))
-                                                      ;; Set up fonts early.
-                                                      ;;--------------------
-                                                      (let ((mono-spaced-font "${config.my.monoFont}")
-                                                       (proportionately-spaced-font "${config.my.font}"))
-                                                       (set-face-attribute 'default nil :family mono-spaced-font :height 180)
-                                                       (set-face-attribute 'fixed-pitch nil :family mono-spaced-font :height 1.0)
-                                                       (set-face-attribute 'variable-pitch nil :family proportionately-spaced-font :height 1.0))
+                                                      ;; Set up fonts on graphical frames only.
+                                                      ;; Never set the default (nil) face: tty frames inherit it and break.
+                                                      (defun my/set-frame-fonts (&optional frame)
+                                                        (when-let ((frame (or frame (selected-frame))))
+                                                          (when (display-graphic-p frame)
+                                                            (let ((mono-spaced-font "${config.my.monoFont}")
+                                                                  (proportionately-spaced-font "${config.my.font}"))
+                                                              (set-face-attribute 'default frame :family mono-spaced-font :height 180)
+                                                              (set-face-attribute 'fixed-pitch frame :family mono-spaced-font :height 1.0)
+                                                              (set-face-attribute 'variable-pitch frame :family proportionately-spaced-font :height 1.0)))))
+                                                      (when-let ((frame (selected-frame)))
+                                                        (my/set-frame-fonts frame))
+                                                      (add-hook 'server-after-make-frame-hook #'my/set-frame-fonts)
 
                                                       ;; auto-save might handle this already 
                                                       (setq make-backup-files nil)
@@ -435,7 +441,34 @@ with lib;
                                   (editorconfig-mode 1)
 
                  (autoload #'nerd-icons-set-font "nerd-icons" "Modify nerd font charsets to use FONT-FAMILY for FRAME." nil)
-                (add-hook 'server-after-make-frame-hook #'nerd-icons-set-font)
+                (defun my/nerd-icons-set-font (&optional frame)
+                  (when-let ((frame (or frame (selected-frame))))
+                    (when (display-graphic-p frame)
+                      (nerd-icons-set-font frame))))
+                (add-hook 'server-after-make-frame-hook #'my/nerd-icons-set-font)
+
+                ;; Some packages add frame hooks expecting a frame argument; Emacs
+                ;; occasionally calls them with none on tty frames (emacsclient -nw).
+                (defun my/wrap-frame-hook (fn)
+                  (if (and (symbolp fn) (get fn 'my/safe-frame-hook))
+                      (get fn 'my/safe-frame-hook)
+                    (let ((wrapper
+                           (lambda (&rest args)
+                             (condition-case-unless-debug err
+                                 (apply fn args)
+                               (wrong-number-of-arguments
+                                (if args
+                                    (signal (car err) (cdr err))
+                                  (funcall fn (selected-frame))))))))
+                      (when (symbolp fn)
+                        (put fn 'my/safe-frame-hook wrapper))
+                      wrapper)))
+
+                (defun my/install-safe-frame-hooks ()
+                  (setq server-after-make-frame-hook
+                        (mapcar #'my/wrap-frame-hook server-after-make-frame-hook)))
+
+                (add-hook 'after-init-hook #'my/install-safe-frame-hooks 999)
 
                 (setq treesit-font-lock-level 4)
 
@@ -1326,6 +1359,12 @@ with lib;
                     after = [ "corfu" ];
                     config = ''
                       (add-to-list 'corfu-margin-formatters #'nerd-icons-corfu-formatter)
+                      (remove-hook 'server-after-make-frame-hook #'nerd-icons-corfu--refresh-space)
+                      (add-hook 'server-after-make-frame-hook
+                                (lambda (frame)
+                                  (when (display-graphic-p frame)
+                                    (with-selected-frame frame
+                                      (nerd-icons-corfu--refresh-space)))))
                     '';
                   };
                   nerd-icons-dired = {
@@ -2090,7 +2129,7 @@ with lib;
                     '';
                   };
                   org-noter-pdftools = {
-                    enable =false;
+                    enable = false;
 
                     after = [ "org-noter" ];
                     config = ''
@@ -3007,8 +3046,14 @@ with lib;
                        (ef-themes-select 'ef-owl))
                     '';
                     config = ''
-                      ;; Load theme after display initialization (fixes Emacs 31 color-name-to-rgb issue)
-                      (load-theme 'ef-owl :no-confirm)
+                      ;; Load theme on graphical frames only (ef-themes breaks tty frames).
+                      (defun my/load-graphical-theme (&optional frame)
+                        (when-let ((frame (or frame (selected-frame))))
+                          (when (display-graphic-p frame)
+                            (load-theme 'ef-owl :no-confirm))))
+                      (when-let ((frame (selected-frame)))
+                        (my/load-graphical-theme frame))
+                      (add-hook 'server-after-make-frame-hook #'my/load-graphical-theme)
                     '';
                     bind = {
                       "C-c t l" = "my/select-light-theme";
@@ -3370,7 +3415,19 @@ with lib;
                           :scroll-bar-width 8
                           :fringe-width 8))
                     '';
-                    config = "(spacious-padding-mode 1)";
+                    config = ''
+                      (defun my/enable-spacious-padding (&optional frame)
+                        (when-let ((frame (or frame (selected-frame))))
+                          (when (display-graphic-p frame)
+                            (with-selected-frame frame
+                              (unless spacious-padding-mode
+                                (spacious-padding-mode 1))
+                              (spacious-padding-set-parameters-of-selected-frame)))))
+                      (when-let ((frame (selected-frame)))
+                        (my/enable-spacious-padding frame))
+                      (remove-hook 'server-after-make-frame-hook #'spacious-padding-set-parameters-of-selected-frame)
+                      (add-hook 'server-after-make-frame-hook #'my/enable-spacious-padding)
+                    '';
                   };
 
                   toggle-term = {


### PR DESCRIPTION
Guard fonts, themes, spacious-padding, and prot-modeline for graphical frames only, and wrap server-after-make-frame hooks so missing frame args no longer raise wrong-number-of-arguments errors.